### PR TITLE
Don't use COUNT when not necessary

### DIFF
--- a/lib/rails/pagination.rb
+++ b/lib/rails/pagination.rb
@@ -61,8 +61,14 @@ module Rails
     def total_count(collection, options)
       total_count = if ApiPagination.config.paginator == :kaminari
         paginate_array_options = options[:paginate_array_options]
-        paginate_array_options[:total_count] if paginate_array_options
+
+        if paginate_array_options
+          paginate_array_options[:total_count]
+        elsif collection.current_page == 1 && collection.size < collection.limit_value
+          collection.size
+        end
       end
+
       total_count || ApiPagination.total_from(collection)
     end
 

--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -240,6 +240,20 @@ describe NumbersController, :type => :controller do
           expect(response.header['Total'].to_i).to eq total_header
         end
       end
+
+      context 'when only one page of results' do
+        it 'uses the collection size instead of the DB count' do
+          expect(ApiPagination).not_to receive(:total_from)
+          get :index, params: {count: 9}
+        end
+      end
+
+      context 'when more than one page of results' do
+        it 'uses the DB count instead of the collection size' do
+          expect(ApiPagination).to receive(:total_from)
+          get :index, params: {count: 30}
+        end
+      end
     end
 
     if [:will_paginate, :kaminari].include?(ApiPagination.config.paginator.to_sym)


### PR DESCRIPTION
When using Kaminari, the total count is retrieved by a COUNT query to the DB. This optimisation uses the collection.size in order to avoid a COUNT query if the collection size is smaller than the per page limit value.
Thanks to @bazlo